### PR TITLE
Add toJSObject 

### DIFF
--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -18,6 +18,6 @@ test('should inspect', (context, document) => {
   expect(util.inspect({a: 'hello'})).toBe("{ a: 'hello' }")
   expect(util.inspect(NSMakeRange(0, 10))).toBe(`NSRange { location: 0, length: 10 }`)
   expect(util.inspect(context.command)).toBe(String(context.command))
-  expect(util.inspect(document.pages[0])).toBe(`{ type: 'Page',\n  id: '${document.pages[0].id}',\n  frame: { x: 0, y: 0, width: 0, height: 0 },\n  name: 'Page 1',\n  selected: true,\n  layers: [] }`)
+  expect(util.inspect(document.pages[0])).toBe(`{ type: 'Page',\n  id: '${document.pages[0].id}',\n  frame: { x: 0, y: 0, width: 300, height: 300 },\n  name: 'Page 1',\n  selected: true,\n  layers: [] }`)
   expect(util.inspect({ type: 'Shape', id: '61658700-4746-43A0-BE9C-5191CA209481', style: { type: 'Style', id: 'ED475674-38E5-4673-A7D0-2F0903A0E2D3',opacity: 1,borderOptions:{ startArrowhead: 'None',lineEnd: 'Butt',lineJoin: 'Miter', endArrowhead: 'None', }}})).toBe(`{ type: \'Shape\',\n  id: \'61658700-4746-43A0-BE9C-5191CA209481\',\n  style: \n   { type: \'Style\',\n     id: \'ED475674-38E5-4673-A7D0-2F0903A0E2D3\',\n     opacity: 1,\n     borderOptions: \n      { startArrowhead: \'None\',\n        lineEnd: \'Butt\',\n        lineJoin: \'Miter\',\n        endArrowhead: \'None\' } } }`)
 })

--- a/index.js
+++ b/index.js
@@ -626,6 +626,30 @@ function getNativeClass(arg) {
   }
 }
 
+/**
+ * Coerce common NSObjects to their JS counterparts
+ * @param arg Any object
+ *
+ * Converts NSDictionary, NSArray, NSStirng, and NSNumber to
+ * native JS equivilents.
+ */
+function toJSObject(arg) {
+  if (arg) {
+    if (isObject(arg)) {
+      return toObject(arg)
+    } else if (isArray(arg)) {
+      return toArray(arg)
+    } else if (isString(arg)) {
+      return String(arg)
+    } else if (isNumber(arg)) {
+      return Number(arg)
+    } else if (isBoolean(arg)) {
+      return Boolean(Number(arg))
+    }
+  }
+  return arg
+}
+exports.asJSObject = toJSObject
 
 var assimilatedArrays = ['NSArray', 'NSMutableArray', '__NSArrayM', '__NSSingleObjectArrayI', '__NSArray0']
 function isArray(ar) {

--- a/index.js
+++ b/index.js
@@ -673,7 +673,7 @@ function toArray(object) {
 }
 exports.toArray = toArray;
 
-var assimilatedNumbers = ['__NSCFBoolean']
+var assimilatedBooleans = ['__NSCFBoolean']
 function isBoolean(arg) {
   if (typeof arg === 'boolean') {
     return true

--- a/index.js
+++ b/index.js
@@ -649,7 +649,7 @@ function toJSObject(arg) {
   }
   return arg
 }
-exports.asJSObject = toJSObject
+exports.toJSObject = toJSObject
 
 var assimilatedArrays = ['NSArray', 'NSMutableArray', '__NSArrayM', '__NSSingleObjectArrayI', '__NSArray0']
 function isArray(ar) {


### PR DESCRIPTION
`toJSObject()` automatically maps common cocoa objects to their native JS counterparts

Also fixed what looks like a copy paste issue for isBoolean/assimilatedBooleans.