### PR TITLE
Import `toArray()` in `promisify`

### DIFF
--- a/promisify.js
+++ b/promisify.js
@@ -1,3 +1,4 @@
+var { toArray } = require('./casting')
 var customPromisify = 'promisify'
 
 function promisify(fn) {


### PR DESCRIPTION
Currently, trying to promisify something gives a `ReferenceError: Can't find variable: toArray`. Looking at the code for `promisify`, it looks like `toArray()` is being used without importing it first.

I checked to see if `toArray()` is supposed to be imported as a global, but couldn't find any evidence for it. So I assume this is a real bug. Feel free to change the commit if there's a specific style you want to follow.

I tested this on a local install, and it works correctly.