### PR TITLE
Tweak tests to avoid failures on next version of Sketch

### DIFF
--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -23,7 +23,7 @@ test("should inspect", (context, document) => {
   expect(util.inspect(document.pages[0])).toBe(
     `Page {\n  type: 'Page',\n  id: '${
       document.pages[0].id
-    }',\n  frame: { x: 0, y: 0, width: 0, height: 0 },\n  name: 'Page 1',\n  selected: true,\n  sharedStyleId: null,\n  layers: [  ] }`
+    }',\n  frame: { x: 0, y: 0, width: 0, height: 0 },\n  name: 'Page',\n  selected: true,\n  sharedStyleId: null,\n  layers: [  ] }`
   );
   expect(
     util.inspect({


### PR DESCRIPTION
Howdy 👋 

The default new document in Sketch 64 names its initial page as just "Page", no longer "Page 1", so we're getting a test failure in the automated Jenkins job that tests this repo.

@mathieudutour On a side note, would you be open to a PR that makes the tests in this repo less prone to such breakages in future? E.g. make them more deterministic like [this](https://github.com/skpm/util/blob/master/__tests__/index.test.js#L28-L47) one we provide the input, and less like [this](https://github.com/skpm/util/blob/master/__tests__/index.test.js#L23-L27) one where the input is dynamically provided by Sketch?

Cheers!